### PR TITLE
04.12 22

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,33 @@
 # 小四轴飞控
-version V0.12
+version V0.13
 
-     HEAD
-  M2  ↑  M3
+         HEAD
+	  M2  ↑  M3
 
-   \     /
+	   \     /
 
-     \ /
+	    \   /
 
-     / \
+	     \ /
 
-   /     \
+	     / \
 
-  M1     M4
+	    /   \
+
+	   /     \
+
+	  M1     M4
 
 默认为姿态模式,可通过地面站进行更改。
 
-[!地面站](https://github.com/xd15zhn/GroundStation/blob/master/GroundStation/bin/Release/GroundStation.exe)
+[地面站](https://github.com/xd15zhn/GroundStation/blob/master/GroundStation/bin/Release/GroundStation.exe)
 
 ## 代码说明
 
 ### 关于偏航
 偏航方向为开环控制,即完全放弃偏航方向的反馈
 
-{task.c, IMU_Processing()}将读取到的偏航角速度置零
-
-{imu.c}偏航角速度校准值为0
+{imu.c}互补滤波中z轴角速度不接受加速度计校准
 
 如果考虑偏航方向需注意:
 
@@ -64,5 +66,7 @@ version V0.12
 
 起飞后（即油门超过一定值）2秒内未接收到正确的遥控信号或飞机姿态倾角过大，将进入失控保护模式尝试平稳降落，重新收到信号或姿态恢复正常则可随时恢复控制。
 
+解锁后2秒内未接收到正确的遥控信号自动锁定
+
 ## bug与隐患
-*速度模式参数基本调整完毕,姿态模式由于四元数问题而待调整
+*所有参数基本调整完毕,等待试飞

--- a/user/adrc.c
+++ b/user/adrc.c
@@ -1,11 +1,24 @@
 #include "adrc.h"
 /**************文件说明**********************
 自抗扰控制器相关函数,不一定所有的函数都能用上
+用上的在前
 ********************************************/
-#define adrcR   4
-#define adrcH   0.02  //>=T
-#define adrcD   0.0016  //H*H*R
+
+/**********************
+线性扩张状态观测器
+x1'=x2;x2'=-x2+u+w;
+*@y:输出角速度
+**********************/
 #define T       0.002
+void ADRC_LESO(ADRC_Param *adrc,float y)
+{
+	float e=y-adrc->SpeEst;
+	adrc->SpeEst+=(adrc->AccEst+15.0f*e)*T;
+	adrc->AccEst+=(adrc->u-adrc->AccEst+adrc->w+75.0f*e)*T;
+	adrc->w+=125.0f*e*T;
+}
+
+//以下函数暂时未用上
 
 /**********************
 离散系统最速控制综合函数
@@ -13,6 +26,9 @@
 *@x2:二阶积分器输出的微分
 *@return:控制量输出
 **********************/
+#define adrcR   4
+#define adrcH   0.02  //>=T
+#define adrcD   0.0016  //H*H*R
 float ADRC_fhan(float x1, float x2)
 {
 	float y1 = x1 + adrcH*x2;
@@ -70,17 +86,4 @@ float ADRC_ESO(float u,float y,float b)
 	z2-=220*ADRC_fal(e);
 	float w=z2/b;
 	return w;
-}
-
-/**********************
-线性扩张状态观测器
-x1'=x2;x2'=-a*x2+b*u+w;
-*@y:输出角速度
-**********************/
-void ADRC_LESO(ADRC_Param *adrc,float y)
-{
-	float e=y-adrc->SpeEst;
-	adrc->SpeEst+=(adrc->AccEst+15.0f*e)*T;
-	adrc->AccEst+=(adrc->u-adrc->AccEst+adrc->w+75.0f*e)*T;
-	adrc->w+=125.0f*e*T;
 }

--- a/user/imu.c
+++ b/user/imu.c
@@ -12,8 +12,8 @@ const float accA[3][3]={
 	{0.984375f,-0.019751222473827f,0.005168265332243f},
 	{-0.0390625f,1,0.046875f},
 	{-0.0234375f,0.0390625f,1}};
-short accB[3]={-4644,-4102,1700};
-short gyroB[3]={50,10,0};
+short accB[3]={-4955,-3893,1866};
+short gyroB[3]={447,45,-1};
 
 /***********************
 用事先确定的校准参数校正加速度计原始数据
@@ -98,7 +98,7 @@ void IMUupdate(AxisInt acc,AxisInt gyro,Quaternion *Q)
 	if(q0==0 && q1==0 && q2==0 && q3==0)return;
 	static float ogx=0,ogy=0,ogz=0;  //上一时刻的角速度
 	static float oq0=1,oq1=0,oq2=0,oq3=0;  //上一时刻的四元数
-	static float exInt=0,eyInt=0,ezInt=0;
+	static float exInt=0,eyInt=0;
 	//重力加速度归一化
 	float norm=Q_rsqrt(ax*ax+ay*ay+az*az);
 	ax*=norm;ay*=norm;az*=norm;
@@ -109,15 +109,13 @@ void IMUupdate(AxisInt acc,AxisInt gyro,Quaternion *Q)
 	//向量叉积得出姿态误差
 	float ex=ay*vz-az*vy; 
 	float ey=az*vx-ax*vz;
-	float ez=ax*vy-ay*vx;
 	//对误差进行积分
 	exInt+=ex*Ki;
 	eyInt+=ey*Ki;
-	ezInt+=ez*Ki;
 	//姿态误差补偿到角速度上,修正角速度积分漂移
 	float gx=GyroToRad(gyro.x)+Kp*ex+exInt;
 	float gy=GyroToRad(gyro.y)+Kp*ey+eyInt;
-	float gz=GyroToRad(gyro.z)+Kp*ez+ezInt;
+	float gz=GyroToRad(gyro.z);
 	//改进欧拉法数值求解四元数微分方程
 	float K0=-oq1*ogx-oq2*ogy-oq3*ogz;
 	float K1=oq0*ogx-oq3*ogy+oq2*ogz;

--- a/user/task.h
+++ b/user/task.h
@@ -23,11 +23,12 @@
 #define UNLOCKED      2    //解锁状态
 #define LOCK_TIME     20   //解锁时间,2秒
 
-extern short RCdata[];  //被control.c调用
-extern AxisInt gyro;  //被control.c调用
-extern ADRC_Param adrR,adrP;  //被control.c调用
 extern Quaternion Qpos;  //被control.c调用
+extern short RCdata[];  //被control.c调用
 extern float gyrox,gyroy;  //被control.c调用
+extern ADRC_Param adrR,adrP;  //被control.c调用
+extern float Kyaw,YawOut;  //被control.c调用
+extern float RolBias,PitBias,YawBias;;  //被control.c调用
 
 //在task.c中
 void IMU_Processing(void);


### PR DESCRIPTION
将外环误差控制由四元数改为欧拉角
添加角速度漂移补偿项
删除LESO中的A和B参数
将漂移补偿项作为第4个参数发送至上位机